### PR TITLE
Fixed infinite loop when doing 'Save all' with a filename 'xxxx(2)'.

### DIFF
--- a/Windows/MainWnd/MainWnd.cpp
+++ b/Windows/MainWnd/MainWnd.cpp
@@ -9274,7 +9274,7 @@ void CMainWnd::ShowSaveAllFileDialog()
 						str += strFormat;
 					else {
 						do {
-							_stprintf_s(szNum, _T("%d"), n);
+							_stprintf_s(szNum, _T("%d"), n++);
 							str2 = str;
 							str2 += (tstring)_T("(") + szNum + _T(")");
 							str2 += strFormat;


### PR DESCRIPTION
Fixed the bug that the infinite loop occurs when selecting 'Save all' in the menubar.
It is reproduced if a file with the same file name as the original file, or a file with the file name suffixed (2) exists.
