### PR TITLE
ref #315 実行ファイルをビルド後に、必要なランタイムを同じフォルダにコピー。

### DIFF
--- a/Hayaemon.vcxproj
+++ b/Hayaemon.vcxproj
@@ -74,6 +74,9 @@
       <OptimizeReferences>
       </OptimizeReferences>
     </Link>
+    <PostBuildEvent>
+      <Command>if exist "$(ProjectDir)dll" copy /y "$(ProjectDir)dll\*.dll" $(OutDir)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -99,6 +102,9 @@
       </ModuleDefinitionFile>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
+    <PostBuildEvent>
+      <Command>if exist "$(ProjectDir)dll" copy /y "$(ProjectDir)dll\*.dll" $(OutDir)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="Common\AcceleratorTable.h" />

--- a/copylibs.ps1
+++ b/copylibs.ps1
@@ -1,4 +1,4 @@
-#LIBファイルを直下に、DLLファイルをReleaseフォルダにコピー
+#LIBファイルを直下に、DLLファイルをdllフォルダにコピー
 Copy-Item bass24/c/bass.lib ./ -Force
 Copy-Item bass_aac24/c/bass_aac.lib ./ -Force
 Copy-Item bassalac24/c/bassalac.lib ./ -Force
@@ -14,23 +14,23 @@ Copy-Item basswm24/c/basswma.lib ./ -Force
 Copy-Item tags18/c/tags.lib ./ -Force
 Copy-Item nezplug++/npnez.lib ./ -Force
 Copy-Item jpegsr9c/jpeg-9c/libjpeg.lib ./ -Force
-New-Item Release -ItemType "directory" -Force| Out-Null
-Copy-Item bass24/bass.dll ./Release -Force
-Copy-Item bass_aac24/bass_aac.dll ./Release -Force
-Copy-Item bassalac24/bassalac.dll ./Release -Force
-Copy-Item bass_ape24/bass_ape.dll ./Release -Force
-Copy-Item Hayaemon276/Hayaemon276/BASS_DSHOW.dll ./Release -Force
-Copy-Item bass_fx24/bass_fx.dll ./Release -Force
-Copy-Item bassasio13/bassasio.dll ./Release -Force
-Copy-Item basscd24/basscd.dll ./Release -Force
-Copy-Item bassenc24/bassenc.dll ./Release -Force
-Copy-Item bassflac24/bassflac.dll ./Release -Force
-Copy-Item bassmix24/bassmix.dll ./Release -Force
-Copy-Item basswasapi24/basswasapi.dll ./Release -Force
-Copy-Item basswm24/basswma.dll ./Release -Force
-Copy-Item tags18/tags.dll ./Release -Force
-Copy-Item nezplug++/npnez.dll ./Release -Force
-Copy-Item mp3infp/x86/mp3infp.dll ./Release -Force
+New-Item dll -ItemType "directory" -Force| Out-Null
+Copy-Item bass24/bass.dll ./dll -Force
+Copy-Item bass_aac24/bass_aac.dll ./dll -Force
+Copy-Item bassalac24/bassalac.dll ./dll -Force
+Copy-Item bass_ape24/bass_ape.dll ./dll -Force
+Copy-Item Hayaemon276/Hayaemon276/BASS_DSHOW.dll ./dll -Force
+Copy-Item bass_fx24/bass_fx.dll ./dll -Force
+Copy-Item bassasio13/bassasio.dll ./dll -Force
+Copy-Item basscd24/basscd.dll ./dll -Force
+Copy-Item bassenc24/bassenc.dll ./dll -Force
+Copy-Item bassflac24/bassflac.dll ./dll -Force
+Copy-Item bassmix24/bassmix.dll ./dll -Force
+Copy-Item basswasapi24/basswasapi.dll ./dll -Force
+Copy-Item basswm24/basswma.dll ./dll -Force
+Copy-Item tags18/tags.dll ./dll -Force
+Copy-Item nezplug++/npnez.dll ./dll -Force
+Copy-Item mp3infp/x86/mp3infp.dll ./dll -Force
 
 #各展開ファイルをバックアップフォルダに移動して終了
 Remove-Item ./.backup/bass24 -Recurse -Force


### PR DESCRIPTION
getlibs.batのdllファイルのコピー先を、Releaseフォルダからdllフォルダに変更。
ビルド後イベントに、dllフォルダのdllを実行ファイルと同じフォルダにコピーするコマンドを記述。